### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,10 +1,18 @@
+#
+# This action runs when `tidier-cli` has been changed,
+# but `tidier-core` has not. When `tidier-core` changes,
+# all packages are re-released with the new version,
+# regardless if the code for the dependent project changed or not.
+#
+
 name: on-push
 on:
   push:
     branches: [main]
     paths: 
-      - 'packages/tidier-core/**/*'
-      - 'packages/tidier-cli/**/*'
+      # Run if tidier-cli has changed but NOT if core has changed.
+      # In this case, release-core will run instead, releasing CLI as well.
+      - '{packages/tidier-cli/**/*,!packages/tidier-core/**/*}'
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -16,12 +24,6 @@ jobs:
       - run: yarn
       - run: yarn build:core
       - run: yarn build:test
-      - run: yarn test:core
-      - run: yarn test:cli
-      - run: yarn release:core
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: yarn prepare:cli
       - run: yarn build:cli
       - run: yarn release:cli

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,0 +1,35 @@
+#
+# When tidier-core is updated, all dependent packages are released as well,
+# regardless of whether dependent packages were touched.
+#
+
+name: on-push
+on:
+  push:
+    branches: [main]
+    paths: 
+      - 'packages/tidier-core/**/*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: yarn
+      - run: yarn build:core
+      - run: yarn build:test
+      - run: yarn test:core
+      - run: yarn test:cli
+      - run: yarn release:core
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: yarn prepare:cli
+      - run: yarn build:cli
+      - run: yarn release:cli
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^8.4.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "prettier": "^2.5.1",
-    "semantic-release": "^18.0.1"
+    "semantic-release": "^18.0.1",
+    "semantic-release-monorepo": "^7.0.5"
   }
 }

--- a/packages/tidier-cli/package.json
+++ b/packages/tidier-cli/package.json
@@ -10,6 +10,8 @@
     "node": ">=14.17.0"
   },
   "release": {
+    "extends": "semantic-release-monorepo",
+    "tagFormat": "cli-v${version}",
     "branches": [
       "main"
     ]
@@ -19,7 +21,7 @@
     "test": "jest",
     "build": "rimraf dist/ *.tsbuildinfo && tsc -b tsconfig.production.json",
     "prepare": "yarn upgrade tidier-core --latest",
-    "release": "semantic-release --tag-format 'cli-v${version}'"
+    "release": "semantic-release"
   },
   "dependencies": {
     "colors": "^1.4.0",

--- a/packages/tidier-core/package.json
+++ b/packages/tidier-core/package.json
@@ -10,6 +10,8 @@
     "access": "public"
   },
   "release": {
+    "extends": "semantic-release-monorepo",
+    "tagFormat": "core-v${version}",
     "branches": [
       "main"
     ]
@@ -17,7 +19,7 @@
   "scripts": {
     "test": "jest --coverage",
     "build": "rimraf dist/ *.tsbuildinfo && tsc -b tsconfig.production.json",
-    "release": "semantic-release --tag-format 'core-v${version}'"
+    "release": "semantic-release"
   },
   "dependencies": {
     "change-case": "^4.1.2",


### PR DESCRIPTION
Attempt to fix release workflows by A) using `semantic-release-monorepo` to only include changes for one project at the time, and B) splitting release scripts.