### PR TITLE
Reduce bundle size

### DIFF
--- a/packages/tidier-cli/.npmignore
+++ b/packages/tidier-cli/.npmignore
@@ -1,0 +1,6 @@
+src/
+coverage/
+jest.config.js
+tsconfig.json
+tsconfig.production.json
+*.tsbuildinfo

--- a/packages/tidier-core/.npmignore
+++ b/packages/tidier-core/.npmignore
@@ -1,0 +1,6 @@
+src/
+coverage/
+jest.config.js
+tsconfig.json
+tsconfig.production.json
+*.tsbuildinfo


### PR DESCRIPTION
Currently tidier-core is ~450k, and the bulk of this is the coverage report.

This PR adds an `.npmignore` to both tidier-core and tidier-cli to reduce the bundle size.