### PR TITLE
Add package repository and homepage to package metadata

### DIFF
--- a/packages/tidier-cli/package.json
+++ b/packages/tidier-cli/package.json
@@ -4,6 +4,12 @@
   "description": "A CLI for keeping your projects tidier",
   "license": "ISC",
   "author": "mausworks <rasmuswennerstrom@gmail.com>",
+  "homepage": "https://github.com/mausworks/tidier",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mausworks/tidier",
+    "directory": "packages/tidier-cli"
+  },
   "main": "dist/index.js",
   "bin": "tidier",
   "engines": {

--- a/packages/tidier-core/README.md
+++ b/packages/tidier-core/README.md
@@ -63,7 +63,7 @@ const projects = await Projects.discover(folder);
 ```
 
 You can then add projects with `projects.add(project)` remove projects with `projects.remove(path)`,
-and combine projects with `projects.combine(projects)`.
+and combine projects with `projects.combine(otherProjects)`.
 
 Since the `Projects` class manages multiple projects without any inherent hierarchy, 
 all paths that are accepted by its methods must be absolute.
@@ -109,7 +109,7 @@ const details = checkPath(project, "packages/package-a/src/FooBar.ts");
 
 #### Fixing problems
 
-Once you have checked for problems withing a project, you can fix them using the `fix` function.
+Once you have checked for problems within a project, you can fix them using the `fix` function.
 
 ```typescript
 for (const [path, details] of problems) {

--- a/packages/tidier-core/package.json
+++ b/packages/tidier-core/package.json
@@ -5,9 +5,11 @@
   "license": "ISC",
   "author": "mausworks <rasmuswennerstrom@gmail.com>",
   "main": "dist/index.js",
-  "private": false,
-  "publishConfig": {
-    "access": "public"
+  "homepage": "https://github.com/mausworks/tidier",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mausworks/tidier",
+    "directory": "packages/tidier-core"
   },
   "release": {
     "extends": "semantic-release-monorepo",

--- a/packages/tidier-vscode/package.json
+++ b/packages/tidier-vscode/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "displayName": "Tidier",
   "icon": "logo.png",
+  "homepage": "https://github.com/mausworks/tidier",
   "repository": {
     "type": "git",
     "url": "https://github.com/mausworks/tidier",


### PR DESCRIPTION
This is missing, so it's not showing up on NPM.