### PR TITLE
Enable rename overwrites on MacOS as well as Windows

### DIFF
--- a/packages/tidier-cli/src/write.ts
+++ b/packages/tidier-cli/src/write.ts
@@ -6,7 +6,8 @@ export async function write(project: Project, globPatterns: string[]) {
   const basePath = project.folder.relative(resolve(process.cwd()));
   const globs = globPatterns.map((pattern) => Glob.within(basePath, pattern));
   const problems = await check(project, ...globs);
-  const overwrite = process.platform === "win32";
+  const overwrite =
+    process.platform === "win32" || process.platform === "darwin";
 
   for (const [path, details] of problems) {
     try {

--- a/packages/tidier-vscode/CHANGELOG.md
+++ b/packages/tidier-vscode/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Tidies is documented here.
 
+### 1.1.0
+
+Fixes issues with not being able to rename files on MacOS
+
+- Adds the setting `tidier.renameOverwrite.enabled` which is set to 'auto' by default, 
+  which means it's enabled on MacOS and Windows by default, and disabled on Linux.
+
 ### 1.0.0
 
 Initial release, featuring:

--- a/packages/tidier-vscode/package.json
+++ b/packages/tidier-vscode/package.json
@@ -82,6 +82,20 @@
             "warning",
             "error"
           ]
+        },
+        "tidier.renameOverwrite.enabled": {
+          "default": "auto",
+          "description": "Allow Tidier to overwrite files when renaming.",
+          "enumDescriptions": [
+            "Enable rename overwrites on Windows & MacOS where it is required for the extension to function",
+            "Never allow Tidier to overwrite files by renaming",
+            "Always allow Tidier to overwrite files by renaming"
+          ],
+          "enum": [
+            "auto",
+            "never",
+            "always"
+          ]
         }
       }
     },

--- a/packages/tidier-vscode/src/context.ts
+++ b/packages/tidier-vscode/src/context.ts
@@ -151,16 +151,21 @@ export class TidierContext {
   }
 }
 
-// There doesn't seem to be anything built into the VSCode
-// extension API that allows you to get the platform.
-const isWindows = () => Boolean(env.appRoot && env.appRoot[0] !== "/");
+function renameOverwriteEnabled() {
+  const enabled = settings.renameOverwrite.enabled();
+
+  if (enabled === "auto") {
+    return (
+      env.appHost === "desktop" &&
+      (process.platform === "darwin" || process.platform === "win32")
+    );
+  } else {
+    return enabled === "always";
+  }
+}
 
 async function attemptFixes(project: Project, problems: readonly Problem[]) {
-  // Windows being weird:
-  // The Windows API for `stat` is case-insensitive, unlike NTFS.
-  // This means that if we stat "FooBar.js" when renaming from "fooBar.js",
-  // it will say that "FooBar.js" does indeed exist, even though it's named "fooBar.js".
-  const overwrite = isWindows();
+  const overwrite = renameOverwriteEnabled();
 
   for (const problem of problems) {
     try {

--- a/packages/tidier-vscode/src/extension.ts
+++ b/packages/tidier-vscode/src/extension.ts
@@ -5,7 +5,6 @@ import {
   FileDeleteEvent,
   ExtensionContext,
   Disposable,
-  Uri,
   FileCreateEvent,
   FileRenameEvent,
   TextDocument,
@@ -53,24 +52,6 @@ export function deactivate() {
   output.unregisterOutputChannel();
 
   disposables.forEach((disposable) => disposable.dispose());
-}
-
-async function resolveInProject(uri: Uri) {
-  const project = tidier.projects.bestMatch(uri.path);
-
-  if (project) {
-    const relative = project.folder.relative(uri.path);
-    const type = await project.folder.entryType(relative);
-
-    if (type) {
-      return [project, type];
-    } else {
-      output.log(`Cannot resolve ${uri.path} to a known entry type.`);
-      output.log(`Either it cannot be found or is neither a folder or file.`);
-    }
-  }
-
-  return null;
 }
 
 async function onCreateFile(event: FileCreateEvent) {

--- a/packages/tidier-vscode/src/settings.ts
+++ b/packages/tidier-vscode/src/settings.ts
@@ -11,6 +11,7 @@ const severityMap: Record<string, DiagnosticSeverity> = {
 const section = workspace.getConfiguration;
 
 type FeatureType = "all" | "files" | "folders" | "none";
+type RenameOverwriteFeature = "auto" | "always" | "never";
 
 export const isEnabledFor = (feature: FeatureType, entry: EntryType) =>
   feature === "all"
@@ -36,4 +37,12 @@ export const problems = {
 
     return severityMap[value] ?? DiagnosticSeverity.Information;
   },
+};
+
+export const renameOverwrite = {
+  enabled: () =>
+    section("tidier.renameOverwrite.enabled").get<RenameOverwriteFeature>(
+      "enabled",
+      "auto"
+    ),
 };

--- a/packages/tidier-vscode/src/settings.ts
+++ b/packages/tidier-vscode/src/settings.ts
@@ -41,7 +41,7 @@ export const problems = {
 
 export const renameOverwrite = {
   enabled: () =>
-    section("tidier.renameOverwrite.enabled").get<RenameOverwriteFeature>(
+    section("tidier.renameOverwrite").get<RenameOverwriteFeature>(
       "enabled",
       "auto"
     ),


### PR DESCRIPTION
Adds the setting `tidier.renameOverwrite.enabled` to the VSCode extension which is set to 'auto' by default, which means it's enabled on MacOS and Windows by default, and disabled on Linux.

Also set this default in the CLI to have feature parity.

This closes #33 